### PR TITLE
Add the `FrameParent` parameter to the constructor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ A basic integration of CeiveImOverlay would be as follows:
 ```lua
 local RunService = game:GetService("RunService")
 local CeiveImOverlay = require(...)
-local ImOverlay = CeiveImOverlay.new()
-
-ImOverlay.BackFrame.Parent = AScreenGui
+local ImOverlay = CeiveImOverlay.new(AScreenGui)
 
 -- Could be heartbeat or render stepped, doesnt really matter.
 RunService.RenderStepped:Connect(function()
@@ -27,9 +25,7 @@ A more complex integration could look something like this:
 ```lua
 local RunService = game:GetService("RunService")
 local CeiveImOverlay = require(...)
-local ImOverlay = CeiveImOverlay.new()
-
-ImOverlay.BackFrame.Parent = AScreenGui
+local ImOverlay = CeiveImOverlay.new(AScreenGui)
 
 -- Could be heartbeat or render stepped, doesnt really matter.
 RunService.RenderStepped:Connect(function()

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,9 +8,7 @@ A basic integration of CeiveImOverlay would be as follows:
 ```lua
 local RunService = game:GetService("RunService")
 local CeiveImOverlay = require(...)
-local ImOverlay = CeiveImOverlay.new()
-
-ImOverlay.BackFrame.Parent = AScreenGui
+local ImOverlay = CeiveImOverlay.new(AScreenGui)
 
 -- Could be heartbeat or render stepped, doesnt really matter.
 RunService.RenderStepped:Connect(function()
@@ -29,9 +27,7 @@ A more complex integration could look something like this:
 ```lua
 local RunService = game:GetService("RunService")
 local CeiveImOverlay = require(...)
-local ImOverlay = CeiveImOverlay.new()
-
-ImOverlay.BackFrame.Parent = AScreenGui
+local ImOverlay = CeiveImOverlay.new(AScreenGui)
 
 -- Could be heartbeat or render stepped, doesnt really matter.
 RunService.RenderStepped:Connect(function()

--- a/src/CeiveImOverlay.lua
+++ b/src/CeiveImOverlay.lua
@@ -58,11 +58,12 @@ ImOverlay.__index = ImOverlay
 
 --- @within ImOverlay
 --- @function new
+--- @param FrameParent ScreenGui
 --- @param DefaultY number?
 --- @param TextSize number?
 --- @param UseInset number?
 --- Creates a new overlay object
-function ImOverlay.new(DefaultY: number?, TextSize: number?, UseInset: boolean?): ImOverlay
+function ImOverlay.new(FrameParent: ScreenGui, DefaultY: number?, TextSize: number?, UseInset: boolean?): ImOverlay
     DefaultY = DefaultY or 5
     TextSize = TextSize or 11
     UseInset = (UseInset == nil and true or UseInset)
@@ -84,6 +85,7 @@ function ImOverlay.new(DefaultY: number?, TextSize: number?, UseInset: boolean?)
 	self.BackFrame.Size = (UseInset and InsetSize or DefaultSize)
 	self.BackFrame.Name = "BackFrame"
 	self.BackFrame.Transparency = 1
+	self.BackFrame.Parent = FrameParent
 
 	self.ListLayout = Instance.new("UIListLayout")
 	self.ListLayout.Padding = UDim.new(0, 2)

--- a/src/CeiveImOverlay.lua
+++ b/src/CeiveImOverlay.lua
@@ -1,19 +1,5 @@
 local GuiService = game:GetService("GuiService")
 
-export type ImOverlay = {
-    DefaultY: number,
-    TextSize: number,
-    BackFrame: Frame,
-    ListLayout: UIListLayout,
-    DidUpdate: boolean
-
-    Begin: (self: ImOverlay, Text: string, BackgroundColor: Color3?, TextColor: Color3?) -> (),
-    End: (self: ImOverlay) -> (),
-    Text: (self: ImOverlay, Text: string, BackgroundColor: Color3?, TextColor: Color3?) -> (),
-    Render: (self: ImOverlay) -> (),
-    Destroy: (self: ImOverlay) -> ()
-}
-
 local Font = Font.new("rbxasset://fonts/families/PressStart2P.json")
 
 --- @class ImOverlay
@@ -55,6 +41,14 @@ local Font = Font.new("rbxasset://fonts/families/PressStart2P.json")
 
 local ImOverlay = {}
 ImOverlay.__index = ImOverlay
+
+export type ImOverlay = {
+	DefaultY: number,
+	TextSize: number,
+	BackFrame: Frame,
+	ListLayout: UIListLayout,
+	DidUpdate: boolean
+} & typeof(ImOverlay)
 
 --- @within ImOverlay
 --- @function new

--- a/src/CeiveImOverlay.lua
+++ b/src/CeiveImOverlay.lua
@@ -58,12 +58,12 @@ ImOverlay.__index = ImOverlay
 
 --- @within ImOverlay
 --- @function new
---- @param FrameParent ScreenGui
+--- @param FrameParent LayerCollector
 --- @param DefaultY number?
 --- @param TextSize number?
 --- @param UseInset number?
 --- Creates a new overlay object
-function ImOverlay.new(FrameParent: ScreenGui, DefaultY: number?, TextSize: number?, UseInset: boolean?): ImOverlay
+function ImOverlay.new(FrameParent: LayerCollector, DefaultY: number?, TextSize: number?, UseInset: boolean?): ImOverlay
     DefaultY = DefaultY or 5
     TextSize = TextSize or 11
     UseInset = (UseInset == nil and true or UseInset)

--- a/src/CeiveImOverlay.lua
+++ b/src/CeiveImOverlay.lua
@@ -47,8 +47,14 @@ export type ImOverlay = {
 	TextSize: number,
 	BackFrame: Frame,
 	ListLayout: UIListLayout,
-	DidUpdate: boolean
-} & typeof(ImOverlay)
+	DidUpdate: boolean,
+
+	Begin: (self: ImOverlay, Text: string, BackgroundColor: Color3?, TextColor: Color3?) -> (),
+	End: (self: ImOverlay) -> (),
+	Text: (self: ImOverlay, Text: string, BackgroundColor: Color3?, TextColor: Color3?) -> (),
+	Render: (self: ImOverlay) -> (),
+	Destroy: (self: ImOverlay) -> ()
+}
 
 --- @within ImOverlay
 --- @function new


### PR DESCRIPTION
Currently, you would need to define it as a variable in order to put the parent then do the functions, which can increase the lines of code

```lua
local CeiveImOverlay = require(...)
local ImOverlay = CeiveImOverlay.new()

ImOverlay.BackFrame.Parent = AScreenGui
```

but adding it as a parameter will save some lines of code and not require variable making [still need some variable making for other stuff]

```lua
local CeiveImOverlay = require(...)
local ImOverlay = CeiveImOverlay.new(AScreenGui)
```